### PR TITLE
Use better supported method for decoding bytearray to string

### DIFF
--- a/code.py
+++ b/code.py
@@ -49,7 +49,7 @@ while True:
 
     if message_length > 0:
         try:
-            message_string = bytearray(message_bytes[0:message_length]).decode("utf-8")
+            message_string = str(bytearray(message_bytes[:message_length]), 'utf-8')
             print(message_string)
         except:
             print("Couldn't decode as UTF 8")


### PR DESCRIPTION
See: https://github.com/usefulsensors/tiny_code_reader_trinkey_keyboard/pull/2

It [seems](https://github.com/adafruit/circuitpython/issues/384) not all SAMD21 based CircuitPython boards support bytearray.decode. I get a crash:
'bytearray' object has no attribute 'decode'
on a [CP Sapling](https://circuitpython.org/board/cp_sapling_m0_revb/) dev board.